### PR TITLE
Feature withdraw

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -12,7 +12,7 @@ const AuthContext = createContext<AuthContextType | undefined>(undefined);
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
 
-  // ✅ 페이지 새로고침 시에도 localStorage에 토큰이 있으면 로그인 상태 유지
+  // ✅ 새로고침해도 localStorage에 토큰 있으면 로그인 상태 유지
   useEffect(() => {
     const savedToken = localStorage.getItem('token');
     if (savedToken) {
@@ -24,7 +24,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
   const logout = () => {
     setIsLoggedIn(false);
-    localStorage.removeItem('token'); // ✅ 로그아웃 시 토큰 제거
+    localStorage.removeItem('token'); // 로그아웃 시 토큰 삭제
   };
 
   return (
@@ -36,6 +36,6 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
 export const useAuth = () => {
   const context = useContext(AuthContext);
-  if (!context) throw new Error('AuthContext must be used within an AuthProvider');
+  if (!context) throw new Error('useAuth must be used within an AuthProvider');
   return context;
 };

--- a/src/features/mainpage/service/useWithdrawUser.ts
+++ b/src/features/mainpage/service/useWithdrawUser.ts
@@ -1,0 +1,18 @@
+import { useMutation } from '@tanstack/react-query';
+import api from "@/shared/config/axios";
+
+interface WithdrawUserPayload {
+  password?: string; // 소셜 로그인 사용자는 비밀번호 없이도 가능
+}
+
+export const useWithdrawUser = () => {
+  return useMutation({
+    mutationFn: async ({ password }: WithdrawUserPayload) => {
+      const response = await api.delete('/api/users/me', {
+        params: password ? { password } : {},
+        withCredentials: true, // 인증 필요 시 쿠키 포함
+      });
+      return response.data;
+    },
+  });
+};

--- a/src/features/mainpage/service/useWithdrawUser.ts
+++ b/src/features/mainpage/service/useWithdrawUser.ts
@@ -1,18 +1,116 @@
-import { useMutation } from '@tanstack/react-query';
+import {
+  useMutation,
+  type UseMutationOptions,
+  type UseMutationResult,
+} from '@tanstack/react-query';
 import api from "@/shared/config/axios";
+import { AxiosError } from 'axios';
 
-interface WithdrawUserPayload {
-  password?: string; // 소셜 로그인 사용자는 비밀번호 없이도 가능
+/**
+ * Payload type for the withdrawal request
+ */
+export interface WithdrawUserPayload {
+  /**
+   * User's password (optional for social login users)
+   */
+  password?: string;
 }
 
-export const useWithdrawUser = () => {
-  return useMutation({
-    mutationFn: async ({ password }: WithdrawUserPayload) => {
-      const response = await api.delete('/api/users/me', {
-        params: password ? { password } : {},
-        withCredentials: true, // 인증 필요 시 쿠키 포함
+/**
+ * Successful response type from the withdrawal API
+ */
+export interface WithdrawUserResponse {
+  success: boolean;
+  message: string;
+  data?: Record<string, unknown>;
+  timestamp?: string;
+}
+
+/**
+ * Extended error type for withdrawal operations
+ */
+export interface WithdrawUserError extends Error {
+  message: string;
+  status?: number;
+  code?: string;
+  timestamp?: string;
+}
+
+/**
+ * Custom hook for handling user account withdrawal
+ * @param options Additional TanStack Query options
+ * @returns Mutation object with withdrawal status and methods
+ */
+export const useWithdrawUser = (
+  options?: Omit<
+    UseMutationOptions<WithdrawUserResponse, WithdrawUserError, WithdrawUserPayload>,
+    'mutationFn'
+  >
+): UseMutationResult<WithdrawUserResponse, WithdrawUserError, WithdrawUserPayload> => {
+  const mutationFn = async (payload: WithdrawUserPayload): Promise<WithdrawUserResponse> => {
+    try {
+      const { password } = payload;
+      const params = password ? { password } : undefined;
+      
+      const response = await api.delete<WithdrawUserResponse>('/api/users/me', {
+        params,
+        withCredentials: true,
+        validateStatus: (status) => status < 500, // Don't throw for 4xx errors
       });
-      return response.data;
-    },
+
+      if (!response.data.success) {
+        throw {
+          name: 'WithdrawalError',
+          message: response.data.message || '회원 탈퇴에 실패했습니다.',
+          status: response.status,
+          timestamp: new Date().toISOString(),
+        };
+      }
+
+      return {
+        success: true,
+        message: response.data.message || '회원 탈퇴가 완료되었습니다.',
+        data: response.data.data,
+        timestamp: new Date().toISOString(),
+      };
+    } catch (error) {
+      if (error instanceof AxiosError) {
+        const axiosError = error as AxiosError<{ message?: string }>;
+        const errorMessage = axiosError.response?.data?.message || '회원 탈퇴 중 오류가 발생했습니다.';
+        
+        throw {
+          name: 'WithdrawalError',
+          message: errorMessage,
+          status: axiosError.response?.status,
+          code: axiosError.code,
+          timestamp: new Date().toISOString(),
+        };
+      }
+      
+      // For non-Axios errors
+      const err = error as Error;
+      throw {
+        name: err.name || 'WithdrawalError',
+        message: err.message || '알 수 없는 오류가 발생했습니다.',
+        timestamp: new Date().toISOString(),
+      };
+    }
+  };
+
+  return useMutation(mutationFn, {
+    retry: 1, // Retry once on failure
+    ...options,
   });
+};
+
+/**
+ * Type guard to check if an error is a WithdrawUserError
+ */
+export const isWithdrawUserError = (error: unknown): error is WithdrawUserError => {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'message' in error &&
+    typeof (error as Record<string, unknown>).message === 'string'
+  );
 };

--- a/src/features/mainpage/service/useWithdrawUser.ts
+++ b/src/features/mainpage/service/useWithdrawUser.ts
@@ -1,8 +1,4 @@
-import {
-  useMutation,
-  type UseMutationOptions,
-  type UseMutationResult,
-} from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import api from "@/shared/config/axios";
 import { AxiosError } from 'axios';
 
@@ -10,9 +6,6 @@ import { AxiosError } from 'axios';
  * Payload type for the withdrawal request
  */
 export interface WithdrawUserPayload {
-  /**
-   * User's password (optional for social login users)
-   */
   password?: string;
 }
 
@@ -38,68 +31,58 @@ export interface WithdrawUserError extends Error {
 
 /**
  * Custom hook for handling user account withdrawal
- * @param options Additional TanStack Query options
- * @returns Mutation object with withdrawal status and methods
  */
-export const useWithdrawUser = (
-  options?: Omit<
-    UseMutationOptions<WithdrawUserResponse, WithdrawUserError, WithdrawUserPayload>,
-    'mutationFn'
-  >
-): UseMutationResult<WithdrawUserResponse, WithdrawUserError, WithdrawUserPayload> => {
-  const mutationFn = async (payload: WithdrawUserPayload): Promise<WithdrawUserResponse> => {
-    try {
-      const { password } = payload;
-      const params = password ? { password } : undefined;
-      
-      const response = await api.delete<WithdrawUserResponse>('/api/users/me', {
-        params,
-        withCredentials: true,
-        validateStatus: (status) => status < 500, // Don't throw for 4xx errors
-      });
+export const useWithdrawUser = () => {
+  return useMutation<WithdrawUserResponse, WithdrawUserError, WithdrawUserPayload>({
+    mutationFn: async (payload: WithdrawUserPayload): Promise<WithdrawUserResponse> => {
+      try {
+        const { password } = payload;
+        const params = password ? { password } : undefined;
 
-      if (!response.data.success) {
+        const response = await api.delete<WithdrawUserResponse>('/api/user/me', {
+          params,
+          withCredentials: true,
+          validateStatus: (status) => status < 500,
+        });
+
+        if (!response.data.success) {
+          throw {
+            name: 'WithdrawalError',
+            message: response.data.message || '회원 탈퇴에 실패했습니다.',
+            status: response.status,
+            timestamp: new Date().toISOString(),
+          };
+        }
+
+        return {
+          success: true,
+          message: response.data.message || '회원 탈퇴가 완료되었습니다.',
+          data: response.data.data,
+          timestamp: new Date().toISOString(),
+        };
+      } catch (error) {
+        if (error instanceof AxiosError) {
+          const axiosError = error as AxiosError<{ message?: string }>;
+          const errorMessage = axiosError.response?.data?.message || '회원 탈퇴 중 오류가 발생했습니다.';
+
+          throw {
+            name: 'WithdrawalError',
+            message: errorMessage,
+            status: axiosError.response?.status,
+            code: axiosError.code,
+            timestamp: new Date().toISOString(),
+          };
+        }
+
+        const err = error as Error;
         throw {
-          name: 'WithdrawalError',
-          message: response.data.message || '회원 탈퇴에 실패했습니다.',
-          status: response.status,
+          name: err.name || 'WithdrawalError',
+          message: err.message || '알 수 없는 오류가 발생했습니다.',
           timestamp: new Date().toISOString(),
         };
       }
-
-      return {
-        success: true,
-        message: response.data.message || '회원 탈퇴가 완료되었습니다.',
-        data: response.data.data,
-        timestamp: new Date().toISOString(),
-      };
-    } catch (error) {
-      if (error instanceof AxiosError) {
-        const axiosError = error as AxiosError<{ message?: string }>;
-        const errorMessage = axiosError.response?.data?.message || '회원 탈퇴 중 오류가 발생했습니다.';
-        
-        throw {
-          name: 'WithdrawalError',
-          message: errorMessage,
-          status: axiosError.response?.status,
-          code: axiosError.code,
-          timestamp: new Date().toISOString(),
-        };
-      }
-      
-      // For non-Axios errors
-      const err = error as Error;
-      throw {
-        name: err.name || 'WithdrawalError',
-        message: err.message || '알 수 없는 오류가 발생했습니다.',
-        timestamp: new Date().toISOString(),
-      };
-    }
-  };
-
-  return useMutation(mutationFn, {
-    retry: 1, // Retry once on failure
-    ...options,
+    },
+    retry: 1, // 필요하면 유지
   });
 };
 

--- a/src/pages/LoginRegisterContainer.tsx
+++ b/src/pages/LoginRegisterContainer.tsx
@@ -34,10 +34,6 @@ const LoginRegisterContainer: React.FC = () => {
   //   },
   // ]);
 
-  useEffect(() => {
-    console.log('[더미 USER 데이터]', users);
-  }, [users]);
-
   // ✅ 더미 로그인 로직 - 주석처리
   // const handleLogin = (e: React.FormEvent) => {
   //   e.preventDefault();
@@ -58,31 +54,33 @@ const LoginRegisterContainer: React.FC = () => {
   // };
 
   // ✅ 백엔드 연동 로그인
-  const handleLogin = async (e: React.FormEvent) => {
+const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault();
 
     try {
-      const response = await fetch('http://localhost:8080/api/user/login', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          userId: emailInput.trim(),
-          password: passwordInput,
-        }),
-      });
+        const response = await fetch('http://localhost:8080/api/user/login', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                userId: emailInput.trim(),  // 변수명은 emailInput이지만 실제로는 userId를 보내고 있음
+                password: passwordInput,
+            }),
+        });
 
-      if (response.ok) {
-        login();
-        navigate('/');
-      } else {
-        alert('로그인 실패! 이메일/비밀번호를 확인해주세요.');
-      }
+        const data = await response.json();
+        if (response.ok) {
+            // 토큰 저장
+            localStorage.setItem('token', data.token);
+            login();  // 로그인 상태 업데이트
+            navigate('/');
+        } else {
+            alert(data.error || '로그인 실패! 아이디/비밀번호를 확인해주세요.');
+        }
     } catch (error) {
-      console.error('로그인 오류:', error);
-      alert('로그인 요청 중 오류 발생!');
+        console.error('로그인 오류:', error);
+        alert('로그인 요청 중 오류 발생!');
     }
-  };
-
+};
   // ✅ 백엔드 연동 회원가입
   const handleSignup = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/pages/WithdrawUser.tsx
+++ b/src/pages/WithdrawUser.tsx
@@ -1,0 +1,30 @@
+import { useNavigate } from "react-router-dom";
+
+function WithdrawButton() {
+  const navigate = useNavigate();
+  const { mutate, isPending, isSuccess, isError } = useWithdrawUser();
+
+  const handleWithdraw = () => {
+    console.log("Withdrawal initiated");
+    
+    mutate(
+        { password : prompt('비밀번호를 입력하세요:') || undefined },
+        {
+          onSuccess: (res) => {
+            alert(res.data || '탈퇴 완료되었습니다.');
+            navigate('/')
+            console.log("Withdrawal successful");
+          },
+          onError: (error) => {
+            console.error("Withdrawal failed:", error);
+          },
+        }
+    )
+  };
+
+  return (
+    <button onClick={handleWithdraw} disabled={isPending}>
+        {isPending ? "처리 중..." : isSuccess ? "탈퇴 완료" : isError ? "탈퇴 실패" : "탈퇴하기"}
+    </button>
+  );
+}

--- a/src/pages/WithdrawUser.tsx
+++ b/src/pages/WithdrawUser.tsx
@@ -1,14 +1,23 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useWithdrawUser, type WithdrawUserError } from '@/features/mainpage/service/useWithdrawUser';
-// Simple warning icon SVG
+import { useAuth } from '@/context/AuthContext';
+import Header from '../shared/components/Header'; // ✅ Header 추가
+
 const WarningIcon = () => (
-  <svg className="h-5 w-5 text-yellow-500 mt-0.5 mr-2 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
-    <path fillRule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clipRule="evenodd" />
+  <svg
+    className="h-5 w-5 text-blue-600 mt-0.5 mr-2 flex-shrink-0"
+    fill="currentColor"
+    viewBox="0 0 20 20"
+  >
+    <path
+      fillRule="evenodd"
+      d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z"
+      clipRule="evenodd"
+    />
   </svg>
 );
 
-// Simple close icon SVG
 const CloseIcon = () => (
   <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
@@ -20,7 +29,8 @@ const WithdrawUser = () => {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
-  
+
+  const { logout } = useAuth();
   const { mutate, isPending } = useWithdrawUser();
 
   const handleOpenDialog = () => {
@@ -29,8 +39,6 @@ const WithdrawUser = () => {
   };
 
   const handleCloseDialog = () => {
-
-
     if (!isPending) {
       setIsDialogOpen(false);
       setPassword('');
@@ -44,11 +52,12 @@ const WithdrawUser = () => {
     }
 
     setError(null);
-    
+
     mutate(
       { password: password.trim() || undefined },
       {
         onSuccess: (data) => {
+          logout();
           setTimeout(() => {
             navigate('/', { replace: true });
             alert(data.message || '회원 탈퇴가 완료되었습니다.');
@@ -68,99 +77,121 @@ const WithdrawUser = () => {
   };
 
   return (
-    <div className="max-w-md mx-auto p-6 bg-white rounded-lg shadow-md">
-      <h2 className="text-2xl font-bold text-gray-800 mb-6">회원 탈퇴</h2>
-      
-      <div className="flex items-start p-4 mb-6 bg-yellow-50 rounded-lg border border-yellow-200">
-        <WarningIcon />
-        <p className="text-sm text-yellow-700">
-          탈퇴 시 모든 개인 정보와 데이터가 삭제되며, 복구할 수 없습니다.
-        </p>
-      </div>
+    <>
+      <Header onBack={() => navigate(-1)} />
 
-      <button
-        onClick={handleOpenDialog}
-        disabled={isPending}
-        className="w-full px-4 py-2 bg-red-600 text-white font-medium rounded-md hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-      >
-        {isPending ? '처리 중...' : '회원 탈퇴하기'}
-      </button>
+      <div className="max-w-xl mx-auto p-8 bg-white rounded-lg shadow-xl mt-20">
+        <h2 className="text-3xl font-bold text-gray-900 mb-8">회원 탈퇴</h2>
 
-      {/* Dialog */}
-      {isDialogOpen && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
-          <div className="bg-white rounded-lg w-full max-w-md">
-            <div className="p-6">
-              <div className="flex justify-between items-center mb-4">
-                <h3 className="text-lg font-medium text-gray-900">정말로 탈퇴하시겠습니까?</h3>
-                <button
-                  onClick={handleCloseDialog}
-                  disabled={isPending}
-                  className="text-gray-400 hover:text-gray-500 focus:outline-none"
-                >
-                  <CloseIcon />
-                </button>
-              </div>
-              
-              <p className="text-sm text-gray-500 mb-4">
-                탈퇴 시 모든 개인 정보와 데이터가 삭제되며, 복구할 수 없습니다.
-              </p>
-              
-              <div className="space-y-4">
-                <div>
-                  <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-1">
-                    비밀번호 (소셜 로그인 사용자는 생략 가능)
-                  </label>
-                  <input
-                    id="password"
-                    type="password"
-                    value={password}
-                    onChange={(e) => setPassword(e.target.value)}
-                    onKeyDown={handleKeyDown}
-                    disabled={isPending}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-red-500 focus:border-red-500 disabled:opacity-50"
-                    placeholder="비밀번호를 입력하세요"
-                  />
-                </div>
-                
-                {error && (
-                  <div className="p-3 text-sm text-red-700 bg-red-50 rounded-md">
-                    {error}
-                  </div>
-                )}
-                
-                <div className="flex justify-end space-x-3 pt-2">
+        <div className="flex items-start p-5 mb-8 bg-blue-50 rounded-lg border border-blue-200">
+          <WarningIcon />
+          <p className="text-base text-blue-700 leading-relaxed">
+            탈퇴 시 모든 개인 정보와 데이터가 삭제되며 복구할 수 없습니다.
+          </p>
+        </div>
+
+        <button
+          onClick={handleOpenDialog}
+          disabled={isPending}
+          className="w-full px-5 py-3 bg-blue-600 text-white text-lg font-medium rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        >
+          {isPending ? '처리 중...' : '회원 탈퇴하기'}
+        </button>
+
+        {isDialogOpen && (
+          <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
+            <div className="bg-white rounded-lg w-full max-w-lg shadow-2xl">
+              <div className="p-8">
+                <div className="flex justify-between items-center mb-6">
+                  <h3 className="text-xl font-semibold text-gray-900">정말로 탈퇴하시겠습니까?</h3>
                   <button
-                    type="button"
                     onClick={handleCloseDialog}
                     disabled={isPending}
-                    className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 disabled:opacity-50"
+                    className="text-gray-400 hover:text-gray-500 focus:outline-none"
                   >
-                    취소
+                    <CloseIcon />
                   </button>
-                  <button
-                    type="button"
-                    onClick={handleWithdraw}
-                    disabled={isPending}
-                    className="inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-red-600 border border-transparent rounded-md shadow-sm hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 disabled:opacity-50"
-                  >
-                    {isPending ? (
-                      <>
-                        <svg className="animate-spin -ml-1 mr-2 h-4 w-4 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-                          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                        </svg>
-                        처리 중...
-                      </>
-                    ) : '탈퇴하기'}
-                  </button>
+                </div>
+
+                <p className="text-base text-gray-600 mb-6">
+                  탈퇴 시 모든 개인 정보와 데이터가 삭제되며, 복구할 수 없습니다.
+                </p>
+
+                <div className="space-y-5">
+                  <div>
+                    <label
+                      htmlFor="password"
+                      className="block text-sm font-medium text-gray-700 mb-1"
+                    >
+                      비밀번호 (소셜 로그인 사용자는 생략 가능)
+                    </label>
+                    <input
+                      id="password"
+                      type="password"
+                      value={password}
+                      onChange={(e) => setPassword(e.target.value)}
+                      onKeyDown={handleKeyDown}
+                      disabled={isPending}
+                      className="w-full px-4 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 disabled:opacity-50"
+                      placeholder="비밀번호를 입력하세요"
+                    />
+                  </div>
+
+                  {error && (
+                    <div className="p-4 text-sm text-red-700 bg-red-50 rounded-md">{error}</div>
+                  )}
+
+                  <div className="flex justify-end space-x-4 pt-2">
+                    <button
+                      type="button"
+                      onClick={handleCloseDialog}
+                      disabled={isPending}
+                      className="px-5 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50"
+                    >
+                      취소
+                    </button>
+                    <button
+                      type="button"
+                      onClick={handleWithdraw}
+                      disabled={isPending}
+                      className="inline-flex items-center px-5 py-2 text-sm font-medium text-white bg-blue-600 border border-transparent rounded-md shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50"
+                    >
+                      {isPending ? (
+                        <>
+                          <svg
+                            className="animate-spin -ml-1 mr-2 h-4 w-4 text-white"
+                            xmlns="http://www.w3.org/2000/svg"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                          >
+                            <circle
+                              className="opacity-25"
+                              cx="12"
+                              cy="12"
+                              r="10"
+                              stroke="currentColor"
+                              strokeWidth="4"
+                            ></circle>
+                            <path
+                              className="opacity-75"
+                              fill="currentColor"
+                              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                            ></path>
+                          </svg>
+                          처리 중...
+                        </>
+                      ) : (
+                        '탈퇴하기'
+                      )}
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
-        </div>
-      )}
-    </div>
+        )}
+      </div>
+    </>
   );
 };
 

--- a/src/pages/WithdrawUser.tsx
+++ b/src/pages/WithdrawUser.tsx
@@ -1,30 +1,167 @@
-import { useNavigate } from "react-router-dom";
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useWithdrawUser, type WithdrawUserError } from '@/features/mainpage/service/useWithdrawUser';
+// Simple warning icon SVG
+const WarningIcon = () => (
+  <svg className="h-5 w-5 text-yellow-500 mt-0.5 mr-2 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+    <path fillRule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clipRule="evenodd" />
+  </svg>
+);
 
-function WithdrawButton() {
+// Simple close icon SVG
+const CloseIcon = () => (
+  <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+  </svg>
+);
+
+const WithdrawUser = () => {
   const navigate = useNavigate();
-  const { mutate, isPending, isSuccess, isError } = useWithdrawUser();
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  
+  const { mutate, isPending } = useWithdrawUser();
+
+  const handleOpenDialog = () => {
+    setIsDialogOpen(true);
+    setError(null);
+  };
+
+  const handleCloseDialog = () => {
+
+
+    if (!isPending) {
+      setIsDialogOpen(false);
+      setPassword('');
+      setError(null);
+    }
+  };
 
   const handleWithdraw = () => {
-    console.log("Withdrawal initiated");
+    if (!password.trim() && !window.confirm('정말로 비밀번호 없이 탈퇴하시겠습니까?')) {
+      return;
+    }
+
+    setError(null);
     
     mutate(
-        { password : prompt('비밀번호를 입력하세요:') || undefined },
-        {
-          onSuccess: (res) => {
-            alert(res.data || '탈퇴 완료되었습니다.');
-            navigate('/')
-            console.log("Withdrawal successful");
-          },
-          onError: (error) => {
-            console.error("Withdrawal failed:", error);
-          },
-        }
-    )
+      { password: password.trim() || undefined },
+      {
+        onSuccess: (data) => {
+          setTimeout(() => {
+            navigate('/', { replace: true });
+            alert(data.message || '회원 탈퇴가 완료되었습니다.');
+          }, 500);
+        },
+        onError: (error: WithdrawUserError) => {
+          setError(error.message || '회원 탈퇴 중 오류가 발생했습니다.');
+        },
+      }
+    );
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && !isPending) {
+      handleWithdraw();
+    }
   };
 
   return (
-    <button onClick={handleWithdraw} disabled={isPending}>
-        {isPending ? "처리 중..." : isSuccess ? "탈퇴 완료" : isError ? "탈퇴 실패" : "탈퇴하기"}
-    </button>
+    <div className="max-w-md mx-auto p-6 bg-white rounded-lg shadow-md">
+      <h2 className="text-2xl font-bold text-gray-800 mb-6">회원 탈퇴</h2>
+      
+      <div className="flex items-start p-4 mb-6 bg-yellow-50 rounded-lg border border-yellow-200">
+        <WarningIcon />
+        <p className="text-sm text-yellow-700">
+          탈퇴 시 모든 개인 정보와 데이터가 삭제되며, 복구할 수 없습니다.
+        </p>
+      </div>
+
+      <button
+        onClick={handleOpenDialog}
+        disabled={isPending}
+        className="w-full px-4 py-2 bg-red-600 text-white font-medium rounded-md hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+      >
+        {isPending ? '처리 중...' : '회원 탈퇴하기'}
+      </button>
+
+      {/* Dialog */}
+      {isDialogOpen && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
+          <div className="bg-white rounded-lg w-full max-w-md">
+            <div className="p-6">
+              <div className="flex justify-between items-center mb-4">
+                <h3 className="text-lg font-medium text-gray-900">정말로 탈퇴하시겠습니까?</h3>
+                <button
+                  onClick={handleCloseDialog}
+                  disabled={isPending}
+                  className="text-gray-400 hover:text-gray-500 focus:outline-none"
+                >
+                  <CloseIcon />
+                </button>
+              </div>
+              
+              <p className="text-sm text-gray-500 mb-4">
+                탈퇴 시 모든 개인 정보와 데이터가 삭제되며, 복구할 수 없습니다.
+              </p>
+              
+              <div className="space-y-4">
+                <div>
+                  <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-1">
+                    비밀번호 (소셜 로그인 사용자는 생략 가능)
+                  </label>
+                  <input
+                    id="password"
+                    type="password"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    onKeyDown={handleKeyDown}
+                    disabled={isPending}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-red-500 focus:border-red-500 disabled:opacity-50"
+                    placeholder="비밀번호를 입력하세요"
+                  />
+                </div>
+                
+                {error && (
+                  <div className="p-3 text-sm text-red-700 bg-red-50 rounded-md">
+                    {error}
+                  </div>
+                )}
+                
+                <div className="flex justify-end space-x-3 pt-2">
+                  <button
+                    type="button"
+                    onClick={handleCloseDialog}
+                    disabled={isPending}
+                    className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 disabled:opacity-50"
+                  >
+                    취소
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleWithdraw}
+                    disabled={isPending}
+                    className="inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-red-600 border border-transparent rounded-md shadow-sm hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 disabled:opacity-50"
+                  >
+                    {isPending ? (
+                      <>
+                        <svg className="animate-spin -ml-1 mr-2 h-4 w-4 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                        </svg>
+                        처리 중...
+                      </>
+                    ) : '탈퇴하기'}
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
   );
-}
+};
+
+export default WithdrawUser;

--- a/src/shared/components/Footer.tsx
+++ b/src/shared/components/Footer.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useAuth } from '@/context/AuthContext';
 
 interface FooterProps {
   variant?: 'transparent-black' | 'white';
@@ -7,6 +8,7 @@ interface FooterProps {
 
 const Footer: React.FC<FooterProps> = ({ variant = 'white' }) => {
   const navigate = useNavigate();
+  const { isLoggedIn } = useAuth();
 
   const handleWithdrawClick = () => {
     navigate('/withdraw');
@@ -23,23 +25,19 @@ const Footer: React.FC<FooterProps> = ({ variant = 'white' }) => {
       : 'text-gray-500';
 
   return (
-    <footer className={`w-full py-4 ${bgClass} text-xs ${textColor}`}>
-      <div className="max-w-screen-xl mx-auto flex flex-col md:flex-row items-center px-4">
-        {/* ✅ 왼쪽 : 문구 컨테이너 */}
-        <div className="w-full md:flex-1 text-center md:text-center">
-          <p>© 2025 SheetAI. All rights reserved.</p>
-        </div>
-
-        {/* ✅ 오른쪽 : 버튼 컨테이너 */}
-        <div className="w-full md:flex-1 text-center md:text-right mt-2 md:mt-0">
-          <button
-            onClick={handleWithdrawClick}
-            className={`${textColor} hover:text-red-500 transition-colors underline`}
-          >
-            회원 탈퇴
-          </button>
-        </div>
+    <footer className={`w-full relative py-4 ${bgClass} text-xs ${textColor}`}>
+      <div className="max-w-screen-xl mx-auto px-4 text-center">
+        <p>© 2025 SheetAI. All rights reserved.</p>
       </div>
+
+      {isLoggedIn && (
+        <button
+          onClick={handleWithdrawClick}
+          className={`absolute right-4 bottom-4 ${textColor} hover:text-red-500 transition-colors underline`}
+        >
+          회원 탈퇴
+        </button>
+      )}
     </footer>
   );
 };

--- a/src/shared/components/PageRouter.tsx
+++ b/src/shared/components/PageRouter.tsx
@@ -8,7 +8,7 @@ import LoginRequiredPage from '@pages/LoginRequiredPage.tsx';
 
 import NewReportPage from '@pages/NewReportPage.tsx';
 import TestPdf from '@/tests/TestPdf.tsx';
-
+import WithdrawUser from '@pages/WithdrawUser.tsx';
 
 const PageRouter: React.FC = () => {
   return (
@@ -18,15 +18,14 @@ const PageRouter: React.FC = () => {
       <Route path="/search" element={<SearchResultPage />} />
       <Route path="/login" element={<LoginRegisterContainer />} />
       <Route path="/login-required" element={<LoginRequiredPage />} />
-      <Route path="*" element={<Navigate to="/" replace />} />
 
-      <Route path='/' element={<MainPage />} />
-      {/* 여기에 routing 추가 */}
-      <Route path='/search' element={<SearchResultPage />} />
+      {/* ✅ 탈퇴 페이지 라우트 추가 */}
+      <Route path="/withdraw" element={<WithdrawUser />} />
+
       <Route path='/report' element={<NewReportPage />} />
       <Route path='/test-pdf' element={<TestPdf />} />
-      <Route path='*' element={<Navigate to='/' replace />} />
 
+      <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>
   );
 };

--- a/src/shared/config/axios.ts
+++ b/src/shared/config/axios.ts
@@ -12,6 +12,7 @@ import axios from "axios";
 
 const api = axios.create({
   baseURL: "http://localhost:8080",
+  
 });
 
 // ✅ 요청 보낼 때마다 JWT 자동으로 붙이기


### PR DESCRIPTION
### 📌 주요 변경 사항

- **회원 탈퇴(Withdraw) 기능 추가**
  - 사용자가 직접 탈퇴 요청을 할 수 있도록 `WithdrawUser` 컴포넌트 작성
  - 탈퇴 시 비밀번호 입력 및 소셜 로그인 예외 처리
  - 탈퇴 안내 문구, 경고 아이콘, 확인 다이얼로그 포함
  - 탈퇴 시 모든 개인정보와 데이터가 즉시 삭제되며 복구 불가함을 명확히 고지

---

### ⚙️ 구현 세부 내용

- 탈퇴 버튼 클릭 시 다이얼로그 팝업으로 한 번 더 재확인
- 탈퇴 성공 시 자동 로그아웃 처리 및 홈으로 리디렉션
- Tailwind CSS 사용하여 레이아웃 및 경고 스타일 통일
- 배경 Header 추가로 일관된 UI 유지
- Box 폭과 폰트 크기 조정으로 경고문 한 줄 표시

---

### ✅ 테스트 항목

- [x] 회원 탈퇴 시 사용자 정보 DB 삭제 여부
- [x] 탈퇴 후 JWT 토큰 및 로컬스토리지 초기화
- [x] 탈퇴 후 홈으로 이동되는지 확인
- [x] 소셜 로그인 사용자의 비밀번호 입력 생략 케이스 확인

---

### 🔗 관련 이슈

- closes #이슈번호 (필요하다면 연결)

---

### 🙏 추가 참고

- 디자인 통일성을 위해 버튼 색상 및 폰트 사이즈는 기존 메인 컬러 블루로 맞춤
- 필요 시 후속으로 **탈퇴 사유 수집** 같은 추가 기능 논의 가능

